### PR TITLE
[Hotfix] Helper Functions for Plant <--> Nodes Exploration

### DIFF
--- a/retire/explore/explore.py
+++ b/retire/explore/explore.py
@@ -188,6 +188,7 @@ class Explore:
         scaled_legend=False,
         vmax=2.5,
         figsize=(10, 4),
+        show_node_labels=False,
     ):
         """
         Visualize shortest path distances to target nodes in a network component.
@@ -243,10 +244,10 @@ class Explore:
         comp_obj = nx.connected_components(self.G)
         components = [self.G.subgraph(c).copy() for c in comp_obj]
         subGraph = components[component]
+
         fig, ax = plt.subplots(figsize=figsize, dpi=500)
         pos = nx.spring_layout(subGraph, k=0.15, seed=seed)
 
-        # Normalize color range
         if scaled_legend:
             norm = Normalize(vmin=0, vmax=vmax)
         else:
@@ -258,7 +259,6 @@ class Explore:
             plt.cm.tab20c(norm(distances_dict[node])) for node in subGraph.nodes()
         ]
 
-        # Node size
         if size_by_degree:
             node_sizes = [len(subGraph[node]) * 15 for node in subGraph.nodes()]
         else:
@@ -274,7 +274,7 @@ class Explore:
             ax=ax,
         )
 
-        # Highlight target nodes
+        # Highlight target nodes in blue (but no text yet)
         nx.draw_networkx_nodes(
             subGraph,
             pos,
@@ -284,18 +284,31 @@ class Explore:
             node_size=150,
             ax=ax,
         )
-        for node in targets:
-            ax.text(
-                pos[node][0],
-                pos[node][1],
-                "T",
-                color="white",
-                fontsize=6,
-                ha="center",
-                va="center",
-                fontweight="bold",
+
+        if show_node_labels:
+            # Show each node's native NetworkX label
+            nx.draw_networkx_labels(
+                subGraph,
+                pos,
+                labels={node: str(node) for node in subGraph.nodes()},
+                font_size=6,
+                font_color="black",
             )
 
+        else:
+            for node in targets:
+                ax.text(
+                    pos[node][0],
+                    pos[node][1],
+                    "T",
+                    color="white",
+                    fontsize=6,
+                    ha="center",
+                    va="center",
+                    fontweight="bold",
+                )
+
+        # Optional colorbar
         if show_colorbar:
             sm = plt.cm.ScalarMappable(cmap=plt.cm.tab20c, norm=norm)
             sm.set_array([])

--- a/retire/explore/explore.py
+++ b/retire/explore/explore.py
@@ -1285,3 +1285,44 @@ class Explore:
         df_w_groups["Group"] = df_w_groups.index.map(plant_to_group)
 
         return df_w_groups
+
+    def assign_node_ids_to_rawdf(self):
+        """
+        Annotate the raw DataFrame with a new column called 'NodeIDs', which lists all
+        Graph Node IDs that each plant belongs to.
+
+        How it works:
+        -------------
+        - Iterates through all nodes in the graph.
+        - Each graph node can represent one or more plant indices stored in
+        G.nodes[node]["membership"].
+        - This function reverses that relationship:
+            * For each plant, collect all node IDs where it appears in membership.
+        - Adds a column to the DataFrame where each row contains a LIST of node IDs.
+
+        Returns
+        -------
+        pd.DataFrame
+            A copy of the raw DataFrame with a new column 'NodeIDs' where every cell
+            is a list of node IDs that include that plant.
+        """
+
+        # Build plant -> list of node IDs mapping
+        plant_to_nodes = {}
+
+        for node_id in self.G.nodes:
+            plant_indices = self.G.nodes[node_id].get("membership", [])
+            for plant in plant_indices:
+                if plant not in plant_to_nodes:
+                    plant_to_nodes[plant] = []
+                plant_to_nodes[plant].append(node_id)
+
+        # Create a copy of the original DataFrame
+        df_w_nodeids = self.raw_df.copy()
+
+        # Map each row's index to all node IDs it belongs to (default to empty list)
+        df_w_nodeids["NodeIDs"] = df_w_nodeids.index.map(
+            lambda idx: plant_to_nodes.get(idx, [])
+        )
+
+        return df_w_nodeids


### PR DESCRIPTION
## TL;DR:
Make it easier for people to analyze node-level relationships + nuances.

Minimal functionality added, no demos changed. Should be quick to review.

### Key Changes:
- **Add `show_node_labels` arg to path graphs**: Option to toggle Node ID visibility in path graphs.
- **Add `assign_node_ids_to_rawdf()` to `Explore` class**: Function to add node ID lists to the `raw_df` for easier analysis.

### Goal:
To make it easier for users focused on plant-level analysis (rather than group-level) to navigate and analyze node data in `nx` graphs without needing custom functions.

> **Note:** This update does not affect existing demos but adds extra functionality for deeper exploration in notebooks.
